### PR TITLE
Bug fixes and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Released as open source by NCC Group Plc - http://www.nccgroup.com/
 
 Developed by Daniel Compton, daniel dot compton at nccgroup dot com
 
+Fixed and updated by Tom Watson, tom dot watson at nccgroup dot com
+
 https://github.com/nccgroup/cisco-SNMP-enumeration
 
 Released under AGPL see LICENSE for more information
@@ -48,4 +50,5 @@ Screen Shot
 Change Log
 =======================
 
+Version 1.6 - Updated to reflect changes in metasploit filesystem use, made grep case insensitive to avoid false negatives, added new location for community string file & moved from the deprecated msfcli to msfconsole -x syntax
 Version 1.5 - Official release.

--- a/cisc0wn.sh
+++ b/cisc0wn.sh
@@ -111,6 +111,7 @@ if [ -f $COM_PASS1 ]
     else    
         echo ""
         echo -e "\e[00;31mUnable to find the community strings file\e[00m"
+        exit 1
 fi
 
 

--- a/cisc0wn.sh
+++ b/cisc0wn.sh
@@ -6,22 +6,24 @@
 # Twitter = @commonexploits
 # 29/05/2012
 # Requires metasploit, snmpwalk and john the ripper - suggest backtrack as built in (tested on BT5)
-VERSION="1.5" # updated 24/11/12 to include decoding of any local users.
+VERSION="1.6" # updated 15/03/15 by tom dot watson @ nccgroup dot com - See README for details 
 
 #####################################################################################
 # Released as open source by NCC Group Plc - http://www.nccgroup.com/
 
 # Developed by Daniel Compton, daniel dot compton at nccgroup dot com
+# Updated by tom.watson @ nccgroup.com
 
 # https://github.com/nccgroup/cisco-SNMP-enumeration
 
-#Released under AGPL see LICENSE for more information
+# Released under AGPL see LICENSE for more information
 
 ######################################################################################
 
 
 # user config settings
-COM_PASS="/opt/metasploit/msf3/data/wordlists/snmp_default_pass.txt" #location of snmp communities to try
+COM_PASS1="/opt/metasploit/msf3/data/wordlists/snmp_default_pass.txt" #old location of snmp communities to try
+COM_PASS2="/opt/metasploit/apps/pro/data/wordlists/snmp_default_pass.txt" #new location of snmpt communities to try
 OUTPUTDIR="/tmp/" #where config files downloaded will be stored
 SNMPVER="2c" #2c or change to 1
 PORT="161" #default snmp port
@@ -94,6 +96,24 @@ else
 		echo ""
         echo -e "\e[00;31mUnable to find the required screen program, script can continue but won't be able to crack any MD5 passwords\e[00m"
 fi
+
+#Check for default community string file
+if [ -f $COM_PASS1 ]
+    then
+        COM_PASS=$COM_PASS1
+        echo ""
+        echo -e "\e[00;32mI have found the community strings file\e[00m"
+    elif [ -f $COM_PASS2 ]
+        then
+            COM_PASS=$COM_PASS2
+            echo ""
+            echo -e "\e[00;32mI have found the community strings file\e[00m"
+    else    
+        echo ""
+        echo -e "\e[00;31mUnable to find the community strings file\e[00m"
+fi
+
+
 echo ""
 echo "--------------------------------------------- Settings -----------------------------------------------"
 echo ""
@@ -155,7 +175,7 @@ COMNO=`cat "$COM_PASS" | wc -l`
 echo -e "\e[1;33m----------------------------------------------------------------------------\e[00m"
 echo "Now testing read only SNMP communities with "$COMNO" strings - please wait...."
 echo -e "\e[1;33m----------------------------------------------------------------------------\e[00m"
-READCOM=`msfcli auxiliary/scanner/snmp/snmp_login RHOSTS=$CISCOIP PASS_FILE=$COM_PASS RETRIES=1 RPORT=$PORT THREADS=$THREADS VERSION=1 E 2>&1 |grep "READ-ONLY" | cut -d "'" -f 2`
+READCOM=`msfconsole -Lqx "use auxiliary/scanner/snmp/snmp_login; set RHOSTS $CISCOIP; set PASS_FILE $COM_PASS; set RETRIES 1; set RPORT $PORT; set THREADS $THREADS; set VERSION 1 E; run; exit -y" 2>&1 |grep -i "READ-ONLY" | cut -d "'" -f 2`
 clear
 if [ -z "$READCOM" ]
 then
@@ -182,7 +202,8 @@ echo -e "\e[1;33m---------------------------------------------------------------
 echo "Now testing for writable SNMP communities with "$COMNO" strings - please wait...."
 echo -e "\e[1;33m------------------------------------------------------------------------------\e[00m"
 echo ""
-WRITCOM=`msfcli auxiliary/scanner/snmp/snmp_login RHOSTS=$CISCOIP PASS_FILE=$COM_PASS RETRIES=1 RPORT=$PORT THREADS=$THREADS VERSION=1 E 2>&1 |grep "READ-WRITE" | cut -d "'" -f 2`
+WRITCOM=`msfconsole -Lqx "use auxiliary/scanner/snmp/snmp_login; set RHOSTS $CISCOIP; set PASS_FILE $COM_PASS; set RETRIES 1; set RPORT $PORT; set THREADS $THREADS; set VERSION 1 E; run; exit -y" 2>&1 |grep -i "READ-WRITE" | cut -d "'" -f 2`
+#WRITCOM=`msfcli auxiliary/scanner/snmp/snmp_login RHOSTS=$CISCOIP PASS_FILE=$COM_PASS RETRIES=1 RPORT=$PORT THREADS=$THREADS VERSION=1 E 2>&1 |grep -i "READ-WRITE" | cut -d "'" -f 2`
 if [[ -z "$READCOM" && -z "$WRITCOM" ]]
 then
 	echo -e "\e[1;31mI didnt find any read or write community strings. Try setting the COM_PASS value in the script to a custom list and try again. It is possible that the community has a access-list applied. I can't continue, script will exit\e[00m"


### PR DESCRIPTION
The reported bug seemed to be arising from a change in the Metasploit module. Daniel’s script was checking for ‘READ-ONLY’ and ‘READ-WRITE’ but the latest version of the module was returning ‘read-only’ and ‘read-write’. I’ve changed the grep call to grep –I to address this.
In addition, Daniel’s script was looking for the default community strings file in a different location to the latest install path for Metasploit on Kali. I’ve changed his script to look for both the old and new locations.
Lastly, Daniel’s script was using msfcli. This is now deprecated (although currently still supported). I’ve changed the syntax to use msfconsole –x which should mean nothing will break when msfcli goes fully out of support.
